### PR TITLE
1.1.0 alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,21 +12,30 @@ Generates a **Webpack 4 config** for Web applications written in *Typescript*.
 ## Example
 
 package.json:
-````json
-{
-	"scripts": {
-		"build": "webpack --mode production",
-		"watch": "webpack-dev-server --mode development"
-	},
-	"dependencies": {
-		"@wildpeaks/webpack-config-web": "1.0.0",
-		"typescript": "...",
-		"webpack": "...",
-		"webpack-cli": "...",
-		"webpack-dev-server": "...",
-		"whatwg-fetch": "..."
-	}
+````js
+"scripts": {
+
+	// Build for production mode
+	"build": "webpack --mode production",
+
+	// Development server mode
+	"watch": "webpack-dev-server --mode development"
+},
+"dependencies": {
+
+	// This package
+	"@wildpeaks/webpack-config-web": "1.1.0",
+
+	// Peer dependencies
+	"typescript": "...",
+	"webpack": "...",
+	"webpack-cli": "...",
+	"webpack-dev-server": "...",
+
+	// Application-specific dependencies
+	"whatwg-fetch": "..."
 }
+
 ````
 
 webpack.config.js:
@@ -207,9 +216,19 @@ See [customProperties](http://cssnext.io/usage/#features) in the CSSNext documen
 
 
 ---
+### `cssModules`: Boolean
+
+The **CSS Modules** option makes classnames and identifiers globally unique at build time.
+
+Default: `true`.
+
+See [Modules](https://github.com/webpack-contrib/css-loader#modules) in the `css-loader` documentation.
+
+
+---
 ### `browsers`: String[]
 
-Target browsers for CSS Autoprefixer.
+Target browsers for **CSS Autoprefixer**.
 
 Default: `[">0.25%", "ie >= 11"]`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wildpeaks/webpack-config-web",
-  "version": "1.0.1",
+  "version": "1.1.0-alpha",
   "description": "Webpack base config generator for Web apps",
   "author": "Cecile Muller",
   "license": "MIT",
@@ -38,14 +38,14 @@
     "postcss-loader": "2.1.5",
     "source-map-loader": "0.2.3",
     "style-loader": "0.21.0",
-    "ts-loader": "4.3.0",
+    "ts-loader": "4.3.1",
     "ts-node": "6.1.0",
     "url-loader": "1.0.1",
     "webpack-subresource-integrity": "1.1.0-rc.4",
-    "worker-loader": "1.1.1"
+    "worker-loader": "2.0.0"
   },
   "devDependencies": {
-    "@types/node": "10.1.4",
+    "@types/node": "10.3.0",
     "@wildpeaks/eslint-config-commonjs": "4.9.0",
     "eslint": "4.19.1",
     "express": "4.16.3",

--- a/src/getConfig.js
+++ b/src/getConfig.js
@@ -31,6 +31,7 @@ function getRegex(extensions){
  * @property {String} mode Use `production` to optimize the output, `development` for faster builds
  * @property {Number} port Port for Webpack Dev Server
  * @property {Object} cssVariables CSS Variables, e.g. `{themeBackground: 'rebeccapurple'}`
+ * @property {Boolean} cssModules Enables CSS Modules
  * @property {String[]} browsers Target browsers for CSS Autoprefixer
  * @property {String[]} embedLimit Filesize limit to embed assets
  * @property {String[]} embedExtensions File extensions of files to embed as base64 (if small enough) or just copy as-is (if large)
@@ -59,6 +60,7 @@ module.exports = function getConfig({
 	mode = 'production',
 	port = 8000,
 	cssVariables = {},
+	cssModules = true,
 	browsers = ['>0.25%', 'ie >= 11'],
 	embedLimit = 5000,
 	embedExtensions = ['jpg', 'png', 'gif', 'svg'],
@@ -114,6 +116,7 @@ module.exports = function getConfig({
 	strictEqual(cssVariables instanceof RegExp, false, '"cssVariables" should not be a RegExp');
 	strictEqual(cssVariables instanceof Symbol, false, '"cssVariables" should not be a Symbol');
 	strictEqual(typeof cssVariables, 'object', '"cssVariables" should be an Object');
+	strictEqual(typeof cssModules, 'boolean', '"cssModules" should be a Boolean');
 
 	strictEqual(Array.isArray(browsers), true, '"browsers" should be an Array');
 	strictEqual(browsers.length > 0, true, '"browsers" should not be empty');
@@ -306,7 +309,7 @@ module.exports = function getConfig({
 				loader: 'css-loader',
 				options: {
 					minimize: minify,
-					modules: true
+					modules: cssModules
 				}
 			},
 			{

--- a/test/cssModules.spec.js
+++ b/test/cssModules.spec.js
@@ -1,0 +1,42 @@
+/* eslint-env node, jasmine */
+'use strict';
+const {join} = require('path');
+const getConfig = require('..');
+
+
+/**
+ * @param {String} title
+ * @param {Boolean} cssModules
+ * @param {Boolean} expectThrows
+ */
+function testFixture(title, cssModules, expectThrows){
+	it(title, () => {
+		let actualThrows = false;
+		try {
+			getConfig({
+				entry: {
+					dummy: './src/dummy.ts'
+				},
+				rootFolder: __dirname,
+				outputFolder: join(__dirname, 'dummy'),
+				cssModules
+			});
+		} catch(e){
+			actualThrows = true;
+		}
+		expect(actualThrows).toBe(expectThrows);
+	});
+}
+
+testFixture('Valid: true', true, false);
+testFixture('Valid: false', true, false);
+testFixture('Invalid: ""', '', true);
+testFixture('Invalid: "true"', 'true', true);
+testFixture('Invalid: "false"', 'false', true);
+testFixture('Invalid: 123', 123, true);
+testFixture('Invalid: 0', 0, true);
+testFixture('Invalid: NaN', NaN, true);
+testFixture('Invalid: -1', -1, true);
+testFixture('Invalid: {}', {}, true);
+testFixture('Invalid: null', null, true);
+testFixture('Invalid: Symbol', Symbol('true'), true);

--- a/test/fixtures.spec.js
+++ b/test/fixtures.spec.js
@@ -269,7 +269,51 @@ it('CSS Modules', async() => {
 		mode: 'development',
 		entry: {
 			myapp: './css-modules/myapp.ts'
-		}
+		},
+		cssModules: true
+	});
+	const expectedFiles = [
+		'index.html',
+		'myapp.css',
+		'myapp.css.map',
+		'myapp.js',
+		'myapp.js.map'
+	];
+	expect(actualFiles.sort()).toEqual(expectedFiles.sort());
+
+	const browser = await puppeteer.launch();
+	try {
+		const page = await browser.newPage();
+		await page.goto('http://localhost:8888/');
+		const found = await page.evaluate(() => {
+			/* global document */
+			/* global window */
+			const el = document.getElementById('hello');
+			if (el === null){
+				return '#hello not found';
+			}
+			const computed = window.getComputedStyle(el);
+			if (computed.getPropertyValue('color') !== 'rgb(0, 128, 0)'){
+				return 'Bad color';
+			}
+			return 'ok';
+		});
+		expect(found).toBe('ok', 'DOM tests');
+	} finally {
+		await browser.close();
+	}
+});
+
+
+it('CSS without CSS Modules', async() => {
+	const actualFiles = await testFixture({
+		rootFolder,
+		outputFolder,
+		mode: 'development',
+		entry: {
+			myapp: './css-no-modules/myapp.ts'
+		},
+		cssModules: false
 	});
 	const expectedFiles = [
 		'index.html',

--- a/test/fixtures/css-no-modules/myapp.css
+++ b/test/fixtures/css-no-modules/myapp.css
@@ -1,0 +1,4 @@
+
+.myclass {
+	color: rgb(0, 128, 0);
+}

--- a/test/fixtures/css-no-modules/myapp.d.ts
+++ b/test/fixtures/css-no-modules/myapp.d.ts
@@ -1,0 +1,4 @@
+
+declare module '*.css' {
+	// no exports without CSS Modules
+}

--- a/test/fixtures/css-no-modules/myapp.ts
+++ b/test/fixtures/css-no-modules/myapp.ts
@@ -1,0 +1,8 @@
+/* eslint-env browser */
+import './myapp.css';
+
+const mydiv = document.createElement('div');
+mydiv.setAttribute('id', 'hello');
+mydiv.className = 'myclass';
+mydiv.innerText = 'Hello World';
+document.body.appendChild(mydiv);


### PR DESCRIPTION
Adds option `cssModules` to turn off CSS modules (for simpler webapps that don't need to generate globally-unique identifiers & classnames at build time, e.g. when throwing together a quick prototype to test an idea).