### PR TITLE
1.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wildpeaks/webpack-config-web",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Webpack base config generator for Web apps",
   "author": "Cecile Muller",
   "license": "MIT",
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@types/node": "10.7.1",
     "@wildpeaks/eslint-config-commonjs": "5.1.0",
-    "eslint": "5.3.0",
+    "eslint": "5.4.0",
     "express": "4.16.3",
     "jasmine": "3.2.0",
     "puppeteer": "1.7.0",

--- a/src/getConfig.js
+++ b/src/getConfig.js
@@ -309,7 +309,7 @@ module.exports = function getConfig({
 		postcssPresetEnv({
 			browsers,
 			features: {
-				customProperties: {
+				'custom-properties': {
 					variables: cssVariables
 				}
 			}

--- a/test/fixtures.spec.js
+++ b/test/fixtures.spec.js
@@ -348,6 +348,34 @@ it('CSS without CSS Modules', async() => {
 });
 
 
+it('CSS Variables', async() => {
+	const actualFiles = await testFixture({
+		rootFolder,
+		outputFolder,
+		mode: 'development',
+		entry: {
+			myapp: './css-variables/myapp.ts'
+		},
+		cssModules: false,
+		sourcemaps: false,
+		cssVariables: {
+			myvar1: 'green',
+			myvar2: 'blue'
+		}
+	});
+	const expectedFiles = [
+		'index.html',
+		'myapp.css',
+		'myapp.js'
+	];
+	expect(actualFiles.sort()).toEqual(expectedFiles.sort());
+
+	const actual = readFileSync(join(outputFolder, `myapp.css`), 'utf8').trim();
+	const expected = `.myclass1 {color: green;color: var(--myvar1)} .myclass2 {color: blue;color: var(--myvar2)}`;
+	expect(actual).toEqual(expected);
+});
+
+
 it('Assets', async() => {
 	const actualFiles = await testFixture({
 		rootFolder,

--- a/test/fixtures/css-variables/myapp.css
+++ b/test/fixtures/css-variables/myapp.css
@@ -1,0 +1,1 @@
+.myclass1 {color: var(--myvar1)} .myclass2 {color: var(--myvar2)}

--- a/test/fixtures/css-variables/myapp.d.ts
+++ b/test/fixtures/css-variables/myapp.d.ts
@@ -1,0 +1,4 @@
+
+declare module '*.css' {
+	// no exports without CSS Modules
+}

--- a/test/fixtures/css-variables/myapp.ts
+++ b/test/fixtures/css-variables/myapp.ts
@@ -1,0 +1,8 @@
+/* eslint-env browser */
+import './myapp.css';
+
+const mydiv = document.createElement('div');
+mydiv.setAttribute('id', 'hello');
+mydiv.className = 'myclass';
+mydiv.innerText = 'Hello World';
+document.body.appendChild(mydiv);


### PR DESCRIPTION
Fixed the property name that was preventing CSS Variables from being passed to the plugin that replaces CSSNext.