### PR TITLE
2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/wildpeaks/package-webpack-config-web#readme",
   "dependencies": {
-    "clean-webpack-plugin": "1.0.1",
+    "clean-webpack-plugin": "2.0.2",
     "copy-webpack-plugin": "5.0.3",
     "core-js": "3.0.1",
     "css-loader": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
   "homepage": "https://github.com/wildpeaks/package-webpack-config-web#readme",
   "dependencies": {
     "clean-webpack-plugin": "1.0.1",
-    "copy-webpack-plugin": "5.0.2",
+    "copy-webpack-plugin": "5.0.3",
     "core-js": "3.0.1",
     "css-loader": "2.1.1",
     "cssnano": "4.1.10",
     "file-loader": "3.0.1",
-    "html-webpack-include-assets-plugin": "1.0.10",
+    "html-webpack-include-assets-plugin": "2.0.0",
     "html-webpack-plugin": "3.2.0",
     "loader-utils": "1.2.3",
     "mini-css-extract-plugin": "0.6.0",
@@ -48,22 +48,22 @@
     "sass-loader": "7.1.0",
     "source-map-loader": "0.2.4",
     "style-loader": "0.23.1",
-    "ts-loader": "5.3.3",
+    "ts-loader": "6.0.0",
     "url-loader": "1.1.2",
     "webpack-subresource-integrity": "1.3.2",
     "worker-loader": "2.0.0"
   },
   "devDependencies": {
-    "@types/node": "11.13.6",
+    "@types/node": "12.0.2",
     "@wildpeaks/eslint-config-commonjs": "5.2.0",
     "eslint": "5.16.0",
     "express": "4.16.4",
     "jasmine": "3.4.0",
-    "puppeteer": "1.14.0",
+    "puppeteer": "1.16.0",
     "recursive-readdir": "2.2.2",
     "rimraf": "2.6.3",
-    "typescript": "3.4.3",
-    "webpack": "4.30.0"
+    "typescript": "3.4.5",
+    "webpack": "4.31.0"
   },
   "peerDependencies": {
     "typescript": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wildpeaks/webpack-config-web",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Webpack base config generator for Web apps",
   "author": "Cecile Muller",
   "license": "MIT",
@@ -41,7 +41,7 @@
     "html-webpack-plugin": "3.2.0",
     "loader-utils": "1.2.3",
     "mini-css-extract-plugin": "0.6.0",
-    "node-sass": "4.11.0",
+    "node-sass": "4.12.0",
     "postcss-loader": "3.0.0",
     "postcss-preset-env": "6.6.0",
     "raw-loader": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/wildpeaks/package-webpack-config-web#readme",
   "dependencies": {
-    "clean-webpack-plugin": "2.0.2",
+    "clean-webpack-plugin": "1.0.1",
     "copy-webpack-plugin": "5.0.3",
     "core-js": "3.0.1",
     "css-loader": "2.1.1",


### PR DESCRIPTION
Updated `node-sass` first (to see if the latest version already fixes the missing binary for Travis CI).