### PR TITLE
4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,84 @@ See [Options](https://github.com/jantimon/html-webpack-plugin#options) in the `h
 
 
 ---
+### `jsFilename`: String
+
+Custom **filename for JS** bundles.
+
+By default, files are named `[name].js` (development mode) or `[hash].[name].js` (production mode).
+
+For example, this generates `assets/scripts/app1.js`:
+````json
+{
+	"entry": {
+		"app1": "./src/example.ts"
+	},
+	"jsFilename": "assets/scripts/[name].js"
+}
+````
+
+---
+### `jsChunkFilename`: String
+
+Custom **filename for JS chunks**.
+
+By default, files are named `chunk.[id].js` (development mode) or `[hash].chunk.[id].js` (production mode).
+
+For example, this generates `assets/scripts/chunk.GENERATED_ID.js`:
+````json
+{
+	"entry": {
+		"app1": "./src/example.ts"
+	},
+	"jsChunkFilename": "assets/scripts/chunk.[id].js"
+}
+````
+
+
+---
+### `webworkerFilename`: String
+
+Custom **filename for Web Worker** bundles.
+
+By default, files are named `[name].js` (development mode) or `[hash].[name].js` (production mode).
+
+For example, this generates `assets/scripts/app1.webworker.js`:
+````json
+{
+	"entry": {
+		"app1": "./src/example.ts"
+	},
+	"webworkerFilename": "assets/scripts/[name].js"
+}
+````
+
+
+---
+### `cssFilename`: String
+
+Custom **filename for CSS** bundles.
+
+By default, files are named `[name].css` (development mode) or `[hash].[name].css` (production mode).
+
+For example, this generates `assets/scripts/app1.css`:
+````json
+{
+	"entry": {
+		"app1": "./src/example.ts"
+	},
+	"cssFilename": "assets/scripts/[name].css"
+}
+````
+
+---
+### `cssChunkFilename`: String
+
+Custom **filename for CSS chunks**.
+
+By default, files are named `'[id].css'`.
+
+
+---
 ### `rootFolder`: String
 
 **Absolute path to the root** folder context.

--- a/README.md
+++ b/README.md
@@ -184,12 +184,9 @@ Custom **filename for JS chunks**.
 
 By default, files are named `chunk.[id].js` (development mode) or `[hash].chunk.[id].js` (production mode).
 
-For example, this generates `assets/scripts/chunk.GENERATED_ID.js`:
+For example, this generates `assets/scripts/chunk.0.js`:
 ````json
 {
-	"entry": {
-		"app1": "./src/example.ts"
-	},
 	"jsChunkFilename": "assets/scripts/chunk.[id].js"
 }
 ````
@@ -202,12 +199,9 @@ Custom **filename for Web Worker** bundles.
 
 By default, files are named `[name].js` (development mode) or `[hash].[name].js` (production mode).
 
-For example, this generates `assets/scripts/app1.webworker.js`:
+For example, this generates `assets/scripts/example.webworker.js` for file `example.webworker.js`:
 ````json
 {
-	"entry": {
-		"app1": "./src/example.ts"
-	},
 	"webworkerFilename": "assets/scripts/[name].js"
 }
 ````
@@ -220,13 +214,13 @@ Custom **filename for CSS** bundles.
 
 By default, files are named `[name].css` (development mode) or `[hash].[name].css` (production mode).
 
-For example, this generates `assets/scripts/app1.css`:
+For example, this generates `assets/stylesheets/app1.css`:
 ````json
 {
 	"entry": {
 		"app1": "./src/example.ts"
 	},
-	"cssFilename": "assets/scripts/[name].css"
+	"cssFilename": "assets/stylesheets/[name].css"
 }
 ````
 
@@ -236,6 +230,28 @@ For example, this generates `assets/scripts/app1.css`:
 Custom **filename for CSS chunks**.
 
 By default, files are named `chunk.[id].css` (development mode) or `[hash].chunk.[id].css` (production mode).
+
+For example, this generates `assets/stylesheets/chunk.0.js`:
+````json
+{
+	"cssChunkFilename": "assets/stylesheets/chunk.[id].js"
+}
+````
+
+
+---
+### `assetFilename`: String
+
+Custom **filename for assets** (images, json, etc..).
+
+By default, files are named `assets/[name].[ext]` (development mode) or `assets/[hash].[name].[ext]` (production mode).
+
+For example, this generates `files/asset.image.jpg` for file `image.jpg`:
+````json
+{
+	"assetFilename": "files/asset.[name].[ext]"
+}
+````
 
 
 ---
@@ -473,17 +489,6 @@ Examples:
 ````
 
 See [Options](https://www.npmjs.com/package/html-webpack-tags-plugin#options) in the `html-webpack-tags-plugin` documentation.
-
-
----
-### `assetsRelativePath`: String
-
-Relative **path to copy files to**.
-
-Note that it only applies to `copyExtensions` and large `embedExtensions` files.
-`copyPatterns` specifies the output path in each pattern instead.
-
-Default: `"assets/"`
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ For example, this generates `assets/scripts/app1.css`:
 
 Custom **filename for CSS chunks**.
 
-By default, files are named `'[id].css'`.
+By default, files are named `chunk.[id].css` (development mode) or `[hash].chunk.[id].css` (production mode).
 
 
 ---

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "src"
   ],
   "scripts": {
+    "test:eslint": "eslint src",
     "test:params": "jasmine test/params-*.spec.js",
     "test:assets": "jasmine test/fixtures-assets.spec.js",
     "test:clean": "jasmine test/fixtures-clean.spec.js",
@@ -20,7 +21,7 @@
     "test:core": "jasmine test/fixtures-core.spec.js",
     "test:optimize": "jasmine test/fixtures-optimize.spec.js",
     "test:webworkers": "jasmine test/fixtures-webworkers.spec.js",
-    "test": "npm run test:params && npm run test:assets&& npm run test:clean && npm run test:core && npm run test:optimize && npm run test:webworkers"
+    "test": "npm run test:eslint && npm run test:params && npm run test:assets&& npm run test:clean && npm run test:core && npm run test:optimize && npm run test:webworkers"
   },
   "repository": "https://github.com/wildpeaks/package-webpack-config-web",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wildpeaks/webpack-config-web",
-  "version": "3.5.0",
+  "version": "4.0.0",
   "description": "Webpack base config generator for Web apps",
   "author": "Cecile Muller",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wildpeaks/webpack-config-web",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Webpack base config generator for Web apps",
   "author": "Cecile Muller",
   "license": "MIT",
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/wildpeaks/package-webpack-config-web#readme",
   "dependencies": {
     "clean-webpack-plugin": "3.0.0",
-    "copy-webpack-plugin": "5.0.3",
+    "copy-webpack-plugin": "5.0.4",
     "core-js": "3.1.4",
     "css-loader": "3.1.0",
     "cssnano": "4.1.10",
@@ -65,7 +65,7 @@
     "recursive-readdir": "2.2.2",
     "rimraf": "2.6.3",
     "typescript": "3.5.3",
-    "webpack": "4.37.0"
+    "webpack": "4.38.0"
   },
   "peerDependencies": {
     "typescript": "*",

--- a/src/getConfig.d.ts
+++ b/src/getConfig.d.ts
@@ -48,7 +48,7 @@ declare module "@wildpeaks/webpack-config-web" {
 		 *
 		 * @see [Entry Points](https://webpack.js.org/concepts/entry-points/) in the Webpack documentation
 		 */
-		entry: Entry;
+		entry?: Entry;
 
 		/**
 		 * List of **HTML pages** to output.
@@ -130,6 +130,82 @@ declare module "@wildpeaks/webpack-config-web" {
 			inject?: boolean;
 			showErrors?: boolean;
 		}[];
+
+
+		/**
+		 * Custom **filename for JS** bundles.
+		 *
+		 * By default, files are named `[name].js` (development mode) or `[hash].[name].js` (production mode).
+		 *
+		 * For example, this generates `assets/scripts/app1.js`:
+		 * ````json
+		 * {
+		 * 	"entry": {
+		 * 		"app1": "./src/example.ts"
+		 * 	},
+		 * 	"jsFilename": "assets/scripts/[name].js"
+		 * }
+		 * ````
+		 */
+		jsFilename?: string;
+
+		/**
+		 * Custom **filename for JS chunks**.
+		 *
+		 * By default, files are named `chunk.[id].js` (development mode) or `[hash].chunk.[id].js` (production mode).
+		 *
+		 * For example, this generates `assets/scripts/chunk.GENERATED_ID.js`:
+		 * ````json
+		 * {
+		 * 	"entry": {
+		 * 		"app1": "./src/example.ts"
+		 * 	},
+		 * 	"chunkFilename": "assets/scripts/chunk.[id].js"
+		 * }
+		 * ````
+		 */
+		jsChunkFilename?: string;
+
+		/**
+		 * Custom **filename for Web Worker** bundles.
+		 *
+		 * By default, files are named `[name].js` (development mode) or `[hash].[name].js` (production mode).
+		 *
+		 * For example, this generates `assets/scripts/app1.webworker.js`:
+		 * ````json
+		 * {
+		 * 	"entry": {
+		 * 		"app1": "./src/example.ts"
+		 * 	},
+		 * 	"webworkerFilename": "assets/scripts/[name].js"
+		 * }
+		 * ````
+		 */
+		webworkerFilename?: string;
+
+		/**
+		 * Custom **filename for CSS** bundles.
+		 *
+		 * By default, files are named `[name].css` (development mode) or `[hash].[name].css` (production mode).
+		 *
+		 * For example, this generates `assets/scripts/app1.css`:
+		 * ````json
+		 * {
+		 * 	"entry": {
+		 * 		"app1": "./src/example.ts"
+		 * 	},
+		 * 	"cssFilename": "assets/scripts/[name].css"
+		 * }
+		 * ````
+		 */
+		cssFilename?: string;
+
+		/**
+		 * Custom **filename for CSS chunks**.
+		 *
+		 * By default, files are named `'[id].css'`.
+		 */
+		cssChunkFilename?: string;
 
 		/**
 		 * **Absolute path to the root** folder context.

--- a/src/getConfig.d.ts
+++ b/src/getConfig.d.ts
@@ -154,12 +154,9 @@ declare module "@wildpeaks/webpack-config-web" {
 		 *
 		 * By default, files are named `chunk.[id].js` (development mode) or `[hash].chunk.[id].js` (production mode).
 		 *
-		 * For example, this generates `assets/scripts/chunk.GENERATED_ID.js`:
+		 * For example, this generates `assets/scripts/chunk.0.js`:
 		 * ````json
 		 * {
-		 * 	"entry": {
-		 * 		"app1": "./src/example.ts"
-		 * 	},
 		 * 	"jsChunkFilename": "assets/scripts/chunk.[id].js"
 		 * }
 		 * ````
@@ -171,12 +168,9 @@ declare module "@wildpeaks/webpack-config-web" {
 		 *
 		 * By default, files are named `[name].js` (development mode) or `[hash].[name].js` (production mode).
 		 *
-		 * For example, this generates `assets/scripts/app1.webworker.js`:
+		 * For example, this generates `assets/scripts/example.webworker.js` for file `example.webworker.js`:
 		 * ````json
 		 * {
-		 * 	"entry": {
-		 * 		"app1": "./src/example.ts"
-		 * 	},
 		 * 	"webworkerFilename": "assets/scripts/[name].js"
 		 * }
 		 * ````
@@ -188,13 +182,13 @@ declare module "@wildpeaks/webpack-config-web" {
 		 *
 		 * By default, files are named `[name].css` (development mode) or `[hash].[name].css` (production mode).
 		 *
-		 * For example, this generates `assets/scripts/app1.css`:
+		 * For example, this generates `assets/stylesheets/app1.css`:
 		 * ````json
 		 * {
 		 * 	"entry": {
 		 * 		"app1": "./src/example.ts"
 		 * 	},
-		 * 	"cssFilename": "assets/scripts/[name].css"
+		 * 	"cssFilename": "assets/stylesheets/[name].css"
 		 * }
 		 * ````
 		 */
@@ -203,9 +197,30 @@ declare module "@wildpeaks/webpack-config-web" {
 		/**
 		 * Custom **filename for CSS chunks**.
 		 *
-		 * By default, files are named `'[id].css'`.
+		 * By default, files are named `chunk.[id].css` (development mode) or `[hash].chunk.[id].css` (production mode).
+		 *
+		 * For example, this generates `assets/stylesheets/chunk.0.js`:
+		 * ````json
+		 * {
+		 * 	"cssChunkFilename": "assets/stylesheets/chunk.[id].js"
+		 * }
+		 * ````
 		 */
 		cssChunkFilename?: string;
+
+		/**
+		 * Custom **filename for assets** (images, json, etc..).
+		 *
+		 * By default, files are named `assets/[name].[ext]` (development mode) or `assets/[hash].[name].[ext]` (production mode).
+		 *
+		 * For example, this generates `files/asset.image.jpg` for file `image.jpg`:
+		 * ````json
+		 * {
+		 * 	"assetFilename": "files/asset.[name].[ext]"
+		 * }
+		 * ````
+		 */
+		assetFilename?: string;
 
 		/**
 		 * **Absolute path to the root** folder context.
@@ -437,16 +452,6 @@ declare module "@wildpeaks/webpack-config-web" {
 			// links: any;
 			// scripts: any;
 		}[];
-
-		/**
-		 * Relative **path to copy files to**.
-		 *
-		 * Note that it only applies to `copyExtensions` and large `embedExtensions` files.
-		 * `copyPatterns` specifies the output path in each pattern instead.
-		 *
-		 * @default "assets/"
-		 */
-		assetsRelativePath?: string;
 
 		/**
 		 * **Sourcemaps** for scripts & stylesheets.

--- a/src/getConfig.d.ts
+++ b/src/getConfig.d.ts
@@ -160,7 +160,7 @@ declare module "@wildpeaks/webpack-config-web" {
 		 * 	"entry": {
 		 * 		"app1": "./src/example.ts"
 		 * 	},
-		 * 	"chunkFilename": "assets/scripts/chunk.[id].js"
+		 * 	"jsChunkFilename": "assets/scripts/chunk.[id].js"
 		 * }
 		 * ````
 		 */

--- a/src/getConfig.js
+++ b/src/getConfig.js
@@ -2,7 +2,7 @@
 /* eslint-disable max-statements */
 'use strict';
 const {strictEqual} = require('assert');
-const {basename, join, isAbsolute} = require('path');
+const {join, isAbsolute} = require('path');
 const {CleanWebpackPlugin} = require('clean-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const HtmlWebpackTagsPlugin = require('html-webpack-tags-plugin');
@@ -169,7 +169,7 @@ module.exports = function getConfig({
 
 	let actualCssChunkFilename = cssChunkFilename;
 	if (typeof actualCssChunkFilename !== 'string'){
-		actualCssChunkFilename = '[id].css';
+		actualCssChunkFilename = (minify && !skipHashes) ? '[hash].chunk.[id].css' : 'chunk.[id].css';
 	}
 
 	const config = {

--- a/src/getConfig.js
+++ b/src/getConfig.js
@@ -25,6 +25,11 @@ function getRegex(extensions){
 module.exports = function getConfig({
 	entry = {application: './src/index.ts'},
 	pages = [{title: 'Index', filename: 'index.html'}],
+	jsFilename,
+	jsChunkFilename,
+	cssFilename,
+	cssChunkFilename,
+	webworkerFilename,
 	rootFolder = '',
 	outputFolder = '',
 	publicPath = '/',
@@ -79,6 +84,22 @@ module.exports = function getConfig({
 
 	strictEqual(Array.isArray(pages), true, '"pages" should be an Array');
 
+	if ((typeof jsFilename !== 'string') && (typeof jsFilename !== 'undefined')){
+		throw new Error(`"jsFilename" should be a String or undefined`);
+	}
+	if ((typeof jsChunkFilename !== 'string') && (typeof jsChunkFilename !== 'undefined')){
+		throw new Error(`"jsChunkFilename" should be a String or undefined`);
+	}
+	if ((typeof cssFilename !== 'string') && (typeof cssFilename !== 'undefined')){
+		throw new Error(`"cssFilename" should be a String or undefined`);
+	}
+	if ((typeof cssChunkFilename !== 'string') && (typeof cssChunkFilename !== 'undefined')){
+		throw new Error(`"cssChunkFilename" should be a String or undefined`);
+	}
+	if ((typeof webworkerFilename !== 'string') && (typeof webworkerFilename !== 'undefined')){
+		throw new Error(`"webworkerFilename" should be a String or undefined`);
+	}
+
 	strictEqual(typeof port, 'number', '"port" should be a Number');
 	strictEqual(isNaN(port), false, '"port" must not be NaN');
 	strictEqual(port > 0, true, '"port" should be a positive number');
@@ -120,10 +141,37 @@ module.exports = function getConfig({
 	}
 	//endregion
 
+
+	//region Base Config
 	const minify = (mode === 'production');
 	const loaders = [];
 	const plugins = [];
-	//region Base Config
+
+	let actualJsFilename = jsFilename;
+	if (typeof actualJsFilename !== 'string'){
+		actualJsFilename = (minify && !skipHashes) ? '[hash].[name].js' : '[name].js';
+	}
+
+	let actualJsChunkFilename = jsChunkFilename;
+	if (typeof actualJsChunkFilename !== 'string'){
+		actualJsChunkFilename = (minify && !skipHashes) ? '[hash].chunk.[id].js' : 'chunk.[id].js';
+	}
+
+	let actualWebworkerFilename = webworkerFilename;
+	if (typeof actualWebworkerFilename !== 'string'){
+		actualWebworkerFilename = (minify && !skipHashes) ? '[hash].[name].js' : '[name].js';
+	}
+
+	let actualCssFilename = cssFilename;
+	if (typeof actualCssFilename !== 'string'){
+		actualCssFilename = (minify && !skipHashes) ? '[hash].[name].css' : '[name].css';
+	}
+
+	let actualCssChunkFilename = cssChunkFilename;
+	if (typeof actualCssChunkFilename !== 'string'){
+		actualCssChunkFilename = '[id].css';
+	}
+
 	const config = {
 		//region Input
 		target: 'web',
@@ -140,8 +188,8 @@ module.exports = function getConfig({
 			path: actualOutputFolder,
 			pathinfo: false,
 			publicPath,
-			filename: (minify && !skipHashes) ? '[hash].[name].js' : '[name].js',
-			chunkFilename: (minify && !skipHashes) ? '[hash].chunk.[id].js' : 'chunk.[id].js'
+			filename: actualJsFilename,
+			chunkFilename: actualJsChunkFilename
 		},
 		//endregion
 		//region Hints
@@ -250,7 +298,7 @@ module.exports = function getConfig({
 				loader: 'worker-loader',
 				options: {
 					inline: false,
-					name: (minify && !skipHashes) ? '[hash].[name].js' : '[name].js'
+					name: actualWebworkerFilename
 				}
 			}
 		]
@@ -316,8 +364,8 @@ module.exports = function getConfig({
 	});
 	plugins.push(
 		new MiniCssExtractPlugin({
-			filename: (minify && !skipHashes) ? '[hash].[name].css' : '[name].css',
-			chunkFilename: '[id].css'
+			filename: actualCssFilename,
+			chunkFilename: actualCssChunkFilename
 		})
 	);
 	//endregion

--- a/src/getConfig.js
+++ b/src/getConfig.js
@@ -30,6 +30,7 @@ module.exports = function getConfig({
 	cssFilename,
 	cssChunkFilename,
 	webworkerFilename,
+	assetFilename,
 	rootFolder = '',
 	outputFolder = '',
 	publicPath = '/',
@@ -43,7 +44,6 @@ module.exports = function getConfig({
 	copyExtensions = ['woff'],
 	copyPatterns = [],
 	injectPatterns = [],
-	assetsRelativePath = 'assets/',
 	sourcemaps = true,
 	skipPostprocess = false,
 	polyfills = ['core-js/stable/promise'],
@@ -99,6 +99,9 @@ module.exports = function getConfig({
 	if ((typeof webworkerFilename !== 'string') && (typeof webworkerFilename !== 'undefined')){
 		throw new Error(`"webworkerFilename" should be a String or undefined`);
 	}
+	if ((typeof assetFilename !== 'string') && (typeof assetFilename !== 'undefined')){
+		throw new Error(`"assetFilename" should be a String or undefined`);
+	}
 
 	strictEqual(typeof port, 'number', '"port" should be a Number');
 	strictEqual(isNaN(port), false, '"port" must not be NaN');
@@ -123,11 +126,6 @@ module.exports = function getConfig({
 	strictEqual(Array.isArray(webworkerPolyfills), true, '"webworkerPolyfills" should be an Array');
 	strictEqual(typeof skipHashes, 'boolean', '"skipHashes" should be a Boolean');
 	strictEqual(typeof skipReset, 'boolean', '"skipReset" should be a Boolean');
-
-	strictEqual(typeof assetsRelativePath, 'string', '"assetsRelativePath" should be a String');
-	if ((assetsRelativePath !== '') && !assetsRelativePath.endsWith('/')){
-		throw new Error('"assetsRelativePath" must end with "/" when not empty');
-	}
 
 	if (!(webworkerPattern instanceof RegExp)){
 		throw new Error('"webworkerPattern" should be a RegExp');
@@ -170,6 +168,11 @@ module.exports = function getConfig({
 	let actualCssChunkFilename = cssChunkFilename;
 	if (typeof actualCssChunkFilename !== 'string'){
 		actualCssChunkFilename = (minify && !skipHashes) ? '[hash].chunk.[id].css' : 'chunk.[id].css';
+	}
+
+	let actualAssetFilename = assetFilename;
+	if (typeof actualAssetFilename !== 'string'){
+		actualAssetFilename = (minify && !skipHashes) ? 'assets/[hash].[name].[ext]' : 'assets/[name].[ext]';
 	}
 
 	const config = {
@@ -380,7 +383,7 @@ module.exports = function getConfig({
 					loader: 'url-loader',
 					options: {
 						limit: embedLimit,
-						name: (minify && !skipHashes) ? `${assetsRelativePath}[hash].[name].[ext]` : `${assetsRelativePath}[name].[ext]`
+						name: actualAssetFilename
 					}
 				}
 			});
@@ -393,7 +396,7 @@ module.exports = function getConfig({
 					loader: 'url-loader',
 					options: {
 						limit: embedLimit,
-						name: (minify && !skipHashes) ? `${assetsRelativePath}[hash].[name].[ext]` : `${assetsRelativePath}[name].[ext]`
+						name: actualAssetFilename
 					}
 				}
 			});
@@ -421,7 +424,7 @@ module.exports = function getConfig({
 				use: {
 					loader: 'file-loader',
 					options: {
-						name: (minify && !skipHashes) ? `${assetsRelativePath}[hash].[name].[ext]` : `${assetsRelativePath}[name].[ext]`
+						name: actualAssetFilename
 					}
 				}
 			});
@@ -433,7 +436,7 @@ module.exports = function getConfig({
 				use: {
 					loader: 'file-loader',
 					options: {
-						name: (minify && !skipHashes) ? `${assetsRelativePath}[hash].[name].[ext]` : `${assetsRelativePath}[name].[ext]`
+						name: actualAssetFilename
 					}
 				}
 			});

--- a/test/fixtures-assets.spec.js
+++ b/test/fixtures-assets.spec.js
@@ -1,4 +1,5 @@
 /* eslint-env node, jasmine */
+/* global document */
 'use strict';
 const {join, relative} = require('path');
 const {mkdirSync} = require('fs');
@@ -100,7 +101,6 @@ it('Assets', async() => {
 		const page = await browser.newPage();
 		await page.goto(`http://localhost:${port}/`);
 		const found = await page.evaluate(() => {
-			/* global document */
 			const container = document.getElementById('assets');
 			if (container === null){
 				return '#assets not found';
@@ -241,7 +241,6 @@ it('Raw imports', async() => {
 		const page = await browser.newPage();
 		await page.goto(`http://localhost:${port}/`);
 		const found = await page.evaluate(() => {
-			/* global document */
 			const el1 = document.getElementById('hello1');
 			if (el1 === null){
 				return '#hello1 not found';

--- a/test/fixtures-assets.spec.js
+++ b/test/fixtures-assets.spec.js
@@ -81,7 +81,7 @@ it('Assets', async() => {
 		embedLimit: 5000,
 		embedExtensions: ['jpg', 'png'],
 		copyExtensions: ['gif', 'json'],
-		assetsRelativePath: 'myimages/'
+		assetFilename: 'myimages/[name].[ext]'
 	});
 	const expectedFiles = [
 		'index.html',

--- a/test/fixtures-core.spec.js
+++ b/test/fixtures-core.spec.js
@@ -352,7 +352,7 @@ it('Inject Patterns', async() => {
 		sourcemaps: false,
 		polyfills: [],
 		publicPath: '/mypublic/',
-		assetsRelativePath: 'myassets/',
+		assetFilename: 'myassets/[name].[ext]',
 		injectPatterns: [
 			{
 				append: false,

--- a/test/fixtures-core.spec.js
+++ b/test/fixtures-core.spec.js
@@ -107,6 +107,45 @@ it('Basic', async() => {
 });
 
 
+it('Custom filename', async() => {
+	const actualFiles = await testFixture({
+		rootFolder,
+		outputFolder,
+		jsFilename: 'subfolder/custom.[name].js',
+		mode: 'development',
+		entry: {
+			myapp: './basic/myapp.ts'
+		}
+	});
+	const expectedFiles = [
+		'index.html',
+		'subfolder/custom.myapp.js',
+		'subfolder/custom.myapp.js.map'
+	];
+	expect(actualFiles.sort()).toEqual(expectedFiles.sort());
+
+	const browser = await puppeteer.launch();
+	try {
+		const page = await browser.newPage();
+		await page.goto(`http://localhost:${port}/`);
+		const found = await page.evaluate(() => {
+			/* global document */
+			const el = document.getElementById('hello');
+			if (el === null){
+				return '#hello not found';
+			}
+			if (el.innerText !== 'Hello World'){
+				return `Bad #hello.innerText: ${el.innerText}`;
+			}
+			return 'ok';
+		});
+		expect(found).toBe('ok', 'DOM tests');
+	} finally {
+		await browser.close();
+	}
+});
+
+
 it('Multiple independant entries', async() => {
 	const actualFiles = await testFixture({
 		rootFolder,

--- a/test/fixtures-core.spec.js
+++ b/test/fixtures-core.spec.js
@@ -1,4 +1,6 @@
 /* eslint-env node, jasmine */
+/* global document */
+/* global window */
 'use strict';
 const {join, relative} = require('path');
 const {mkdirSync} = require('fs');
@@ -90,7 +92,6 @@ it('Basic', async() => {
 		const page = await browser.newPage();
 		await page.goto(`http://localhost:${port}/`);
 		const found = await page.evaluate(() => {
-			/* global document */
 			const el = document.getElementById('hello');
 			if (el === null){
 				return '#hello not found';
@@ -129,7 +130,6 @@ it('Custom filename', async() => {
 		const page = await browser.newPage();
 		await page.goto(`http://localhost:${port}/`);
 		const found = await page.evaluate(() => {
-			/* global document */
 			const el = document.getElementById('hello');
 			if (el === null){
 				return '#hello not found';
@@ -195,7 +195,6 @@ it('Multiple independant entries', async() => {
 		const page = await browser.newPage();
 		await page.goto(`http://localhost:${port}/app1.html`);
 		const found = await page.evaluate(() => {
-			/* global document */
 			const el = document.getElementById('hello');
 			if (el === null){
 				return '#hello not found';
@@ -215,7 +214,6 @@ it('Multiple independant entries', async() => {
 		const page = await browser.newPage();
 		await page.goto(`http://localhost:${port}/app2.html`);
 		const found = await page.evaluate(() => {
-			/* global document */
 			const el = document.getElementById('hello');
 			if (el === null){
 				return '#hello not found';
@@ -235,7 +233,6 @@ it('Multiple independant entries', async() => {
 		const page = await browser.newPage();
 		await page.goto(`http://localhost:${port}/app3.html`);
 		const found = await page.evaluate(() => {
-			/* global document */
 			const el = document.getElementById('hello');
 			if (el === null){
 				return '#hello not found';
@@ -273,7 +270,6 @@ it('Local Modules', async() => {
 		const page = await browser.newPage();
 		await page.goto(`http://localhost:${port}/`);
 		const found = await page.evaluate(() => {
-			/* global document */
 			const el = document.getElementById('hello');
 			if (el === null){
 				return '#hello not found';
@@ -317,8 +313,6 @@ it('Polyfills', async() => {
 		const page = await browser.newPage();
 		await page.goto(`http://localhost:${port}/`);
 		const found = await page.evaluate(() => {
-			/* global document */
-			/* global window */
 			if (typeof window.EXAMPLE_FAKE_POLYFILL !== 'undefined'){
 				return 'Fake polyfill exists';
 			}
@@ -432,7 +426,6 @@ it('Inject Patterns', async() => {
 		});
 		await page.goto(`http://localhost:${port}/`);
 		const found = await page.evaluate(() => {
-			/* global document */
 			const bodyChildren = document.body.childNodes;
 			if (bodyChildren.length !== 6){
 				return `Wrong body.children.length: ${bodyChildren.length}`;
@@ -593,7 +586,6 @@ it('Multiple pages', async() => {
 		//region page1
 		await page.goto(`http://localhost:${port}/page1.html`);
 		const found1 = await page.evaluate(() => {
-			/* global document */
 			if (document.title !== 'One'){
 				return `Wrong title: "${document.title}"`;
 			}
@@ -619,7 +611,6 @@ it('Multiple pages', async() => {
 		//region page2
 		await page.goto(`http://localhost:${port}/page2.html`);
 		const found2 = await page.evaluate(() => {
-			/* global document */
 			if (document.title !== 'Two'){
 				return `Wrong title: "${document.title}"`;
 			}
@@ -645,7 +636,6 @@ it('Multiple pages', async() => {
 		//region page3
 		await page.goto(`http://localhost:${port}/page3.html`);
 		const found3 = await page.evaluate(() => {
-			/* global document */
 			if (document.title !== 'Three'){
 				return `Wrong title: "${document.title}"`;
 			}
@@ -674,7 +664,6 @@ it('Multiple pages', async() => {
 		//region page4
 		await page.goto(`http://localhost:${port}/subfolder/page4.html`);
 		const found4 = await page.evaluate(() => {
-			/* global document */
 			if (document.title !== 'Four'){
 				return `Wrong title: "${document.title}"`;
 			}
@@ -703,7 +692,6 @@ it('Multiple pages', async() => {
 		//region page5
 		await page.goto(`http://localhost:${port}/page5.html`);
 		const found5 = await page.evaluate(() => {
-			/* global document */
 			if (document.title !== 'Five'){
 				return `Wrong title: "${document.title}"`;
 			}
@@ -750,7 +738,6 @@ it('Multiple pages', async() => {
 		//region page6
 		await page.goto(`http://localhost:${port}/page6.html`);
 		const found6 = await page.evaluate(() => {
-			/* global document */
 			if (document.title !== 'Six - Customized'){
 				return `Wrong title: "${document.title}"`;
 			}

--- a/test/fixtures-css.spec.js
+++ b/test/fixtures-css.spec.js
@@ -112,6 +112,50 @@ it('CSS Modules', async() => {
 });
 
 
+it('CSS Filename', async() => {
+	const actualFiles = await testFixture({
+		rootFolder,
+		outputFolder,
+		cssFilename: 'subfolder/custom.[name].css',
+		mode: 'development',
+		entry: {
+			myapp: './css-modules/myapp.ts'
+		},
+		cssModules: true
+	});
+	const expectedFiles = [
+		'index.html',
+		'subfolder/custom.myapp.css',
+		'subfolder/custom.myapp.css.map',
+		'myapp.js',
+		'myapp.js.map'
+	];
+	expect(actualFiles.sort()).toEqual(expectedFiles.sort());
+
+	const browser = await puppeteer.launch();
+	try {
+		const page = await browser.newPage();
+		await page.goto(`http://localhost:${port}/`);
+		const found = await page.evaluate(() => {
+			/* global document */
+			/* global window */
+			const el = document.getElementById('hello');
+			if (el === null){
+				return '#hello not found';
+			}
+			const computed = window.getComputedStyle(el);
+			if (computed.getPropertyValue('color') !== 'rgb(0, 128, 0)'){
+				return 'Bad color: ' + computed.getPropertyValue('color');
+			}
+			return 'ok';
+		});
+		expect(found).toBe('ok', 'DOM tests');
+	} finally {
+		await browser.close();
+	}
+});
+
+
 it('CSS without CSS Modules', async() => {
 	const actualFiles = await testFixture({
 		rootFolder,

--- a/test/fixtures-css.spec.js
+++ b/test/fixtures-css.spec.js
@@ -1,4 +1,6 @@
 /* eslint-env node, jasmine */
+/* global document */
+/* global window */
 'use strict';
 const {join, relative} = require('path');
 const {mkdirSync} = require('fs');
@@ -9,10 +11,22 @@ const webpack = require('webpack');
 const puppeteer = require('puppeteer');
 const getConfig = require('..');
 const rootFolder = join(__dirname, 'fixtures');
-const outputFolder = join(__dirname, '../out-assets');
+const outputFolder = join(__dirname, '../out-css');
 let app;
 let server;
 const port = 8884;
+
+
+/**
+ * @param {Number} duration
+ */
+function sleep(duration){
+	return new Promise(resolve => {
+		setTimeout(() => {
+			resolve();
+		}, duration);
+	});
+}
 
 
 /**
@@ -93,8 +107,6 @@ it('CSS Modules', async() => {
 		const page = await browser.newPage();
 		await page.goto(`http://localhost:${port}/`);
 		const found = await page.evaluate(() => {
-			/* global document */
-			/* global window */
 			const el = document.getElementById('hello');
 			if (el === null){
 				return '#hello not found';
@@ -137,8 +149,6 @@ it('CSS Filename', async() => {
 		const page = await browser.newPage();
 		await page.goto(`http://localhost:${port}/`);
 		const found = await page.evaluate(() => {
-			/* global document */
-			/* global window */
 			const el = document.getElementById('hello');
 			if (el === null){
 				return '#hello not found';
@@ -180,8 +190,6 @@ it('CSS without CSS Modules', async() => {
 		const page = await browser.newPage();
 		await page.goto(`http://localhost:${port}/`);
 		const found = await page.evaluate(() => {
-			/* global document */
-			/* global window */
 			const el = document.getElementById('hello');
 			if (el === null){
 				return '#hello not found';
@@ -225,8 +233,6 @@ it('CSS Reset', async() => {
 		const page = await browser.newPage();
 		await page.goto(`http://localhost:${port}/`);
 		const found = await page.evaluate(() => {
-			/* global document */
-			/* global window */
 			const el = document.createElement('div');
 			const computed1 = window.getComputedStyle(el);
 			if (computed1.getPropertyValue('color') === 'rgb(0, 0, 128)'){
@@ -272,8 +278,6 @@ it('SCSS: Reset', async() => {
 		const page = await browser.newPage();
 		await page.goto(`http://localhost:${port}/`);
 		const found = await page.evaluate(() => {
-			/* global document */
-			/* global window */
 			const el = document.createElement('div');
 			const computed1 = window.getComputedStyle(el);
 			if (computed1.getPropertyValue('color') === 'rgb(0, 128, 0)'){
@@ -320,8 +324,6 @@ it('SCSS Global Import', async() => {
 		const page = await browser.newPage();
 		await page.goto(`http://localhost:${port}/`);
 		const found = await page.evaluate(() => {
-			/* global document */
-			/* global window */
 			const el = document.createElement('div');
 			const computed1 = window.getComputedStyle(el);
 			if (computed1.getPropertyValue('color') === 'rgb(128, 0, 0)'){
@@ -368,8 +370,6 @@ it('SCSS Global Variables', async() => {
 		const page = await browser.newPage();
 		await page.goto(`http://localhost:${port}/`);
 		const found = await page.evaluate(() => {
-			/* global document */
-			/* global window */
 			const el = document.createElement('div');
 			const computed1 = window.getComputedStyle(el);
 			if (computed1.getPropertyValue('color') === 'rgb(128, 128, 0)'){
@@ -413,8 +413,6 @@ it('SCSS Basic', async() => {
 		const page = await browser.newPage();
 		await page.goto(`http://localhost:${port}/`);
 		const found = await page.evaluate(() => {
-			/* global document */
-			/* global window */
 			const el = document.getElementById('hello');
 			if (el === null){
 				return '#hello not found';
@@ -456,8 +454,6 @@ it('SCSS Import File', async() => {
 		const page = await browser.newPage();
 		await page.goto(`http://localhost:${port}/`);
 		const found = await page.evaluate(() => {
-			/* global document */
-			/* global window */
 			const el = document.getElementById('hello');
 			if (el === null){
 				return '#hello not found';
@@ -499,8 +495,6 @@ it('SCSS Import Module', async() => {
 		const page = await browser.newPage();
 		await page.goto(`http://localhost:${port}/`);
 		const found = await page.evaluate(() => {
-			/* global document */
-			/* global window */
 			const el = document.getElementById('hello');
 			if (el === null){
 				return '#hello not found';
@@ -512,6 +506,307 @@ it('SCSS Import Module', async() => {
 			return 'ok';
 		});
 		expect(found).toBe('ok', 'DOM tests');
+	} finally {
+		await browser.close();
+	}
+});
+
+
+it('CSS Chunks', async() => {
+	const actualFiles = await testFixture({
+		rootFolder,
+		outputFolder,
+		mode: 'development',
+		entry: {
+			myapp: './css-chunks/myapp.ts'
+		},
+		cssModules: true
+	});
+	const expectedFiles = [
+		'index.html',
+		'myapp.css',
+		'myapp.css.map',
+		'myapp.js',
+		'myapp.js.map',
+		'chunk.0.js',
+		'chunk.0.js.map',
+		'chunk.0.css',
+		'chunk.0.css.map'
+	];
+	expect(actualFiles.sort()).toEqual(expectedFiles.sort());
+
+	const browser = await puppeteer.launch();
+	try {
+		const page = await browser.newPage();
+		await page.goto(`http://localhost:${port}/`);
+		const result1 = await page.evaluate(() => {
+			const el = document.getElementById('hello');
+			if (el === null){
+				return '#hello not found';
+			}
+			const computed = window.getComputedStyle(el);
+			if (computed.getPropertyValue('color') !== 'rgb(0, 255, 0)'){
+				return 'Bad color: ' + computed.getPropertyValue('color');
+			}
+			return 'ok';
+		});
+		expect(result1).toBe('ok', 'Sync color');
+
+		await sleep(300);
+		const result2 = await page.evaluate(() => {
+			const el = document.getElementById('hello');
+			if (el === null){
+				return '#hello not found';
+			}
+			const computed = window.getComputedStyle(el);
+			if (computed.getPropertyValue('color') !== 'rgb(0, 0, 255)'){
+				return 'Bad color: ' + computed.getPropertyValue('color');
+			}
+			return 'ok';
+		});
+		expect(result2).toBe('ok', 'Async color');
+	} finally {
+		await browser.close();
+	}
+});
+
+
+it('CSS Chunk Filename', async() => {
+	const actualFiles = await testFixture({
+		rootFolder,
+		outputFolder,
+		cssChunkFilename: 'subfolder/custom.chunk.[id].css',
+		mode: 'development',
+		entry: {
+			myapp: './css-chunks/myapp.ts'
+		},
+		cssModules: true
+	});
+	const expectedFiles = [
+		'index.html',
+		'myapp.css',
+		'myapp.css.map',
+		'myapp.js',
+		'myapp.js.map',
+		'chunk.0.js',
+		'chunk.0.js.map',
+		'subfolder/custom.chunk.0.css',
+		'subfolder/custom.chunk.0.css.map'
+	];
+	expect(actualFiles.sort()).toEqual(expectedFiles.sort());
+
+	const browser = await puppeteer.launch();
+	try {
+		const page = await browser.newPage();
+		await page.goto(`http://localhost:${port}/`);
+		const result1 = await page.evaluate(() => {
+			const el = document.getElementById('hello');
+			if (el === null){
+				return '#hello not found';
+			}
+			const computed = window.getComputedStyle(el);
+			if (computed.getPropertyValue('color') !== 'rgb(0, 255, 0)'){
+				return 'Bad color: ' + computed.getPropertyValue('color');
+			}
+			return 'ok';
+		});
+		expect(result1).toBe('ok', 'Sync color');
+
+		await sleep(300);
+		const result2 = await page.evaluate(() => {
+			const el = document.getElementById('hello');
+			if (el === null){
+				return '#hello not found';
+			}
+			const computed = window.getComputedStyle(el);
+			if (computed.getPropertyValue('color') !== 'rgb(0, 0, 255)'){
+				return 'Bad color: ' + computed.getPropertyValue('color');
+			}
+			return 'ok';
+		});
+		expect(result2).toBe('ok', 'Async color');
+	} finally {
+		await browser.close();
+	}
+});
+
+
+it('SCSS Chunks', async() => {
+	const actualFiles = await testFixture({
+		rootFolder,
+		outputFolder,
+		mode: 'development',
+		entry: {
+			myapp: './scss-chunks/myapp.ts'
+		},
+		cssModules: true
+	});
+	const expectedFiles = [
+		'index.html',
+		'myapp.css',
+		'myapp.css.map',
+		'myapp.js',
+		'myapp.js.map',
+		'chunk.0.js',
+		'chunk.0.js.map',
+		'chunk.0.css',
+		'chunk.0.css.map'
+	];
+	expect(actualFiles.sort()).toEqual(expectedFiles.sort());
+
+	const browser = await puppeteer.launch();
+	try {
+		const page = await browser.newPage();
+		await page.goto(`http://localhost:${port}/`);
+		const result1 = await page.evaluate(() => {
+			const el = document.getElementById('hello');
+			if (el === null){
+				return '#hello not found';
+			}
+			const computed = window.getComputedStyle(el);
+			if (computed.getPropertyValue('color') !== 'rgb(0, 255, 0)'){
+				return 'Bad color: ' + computed.getPropertyValue('color');
+			}
+			return 'ok';
+		});
+		expect(result1).toBe('ok', 'Sync color');
+
+		await sleep(300);
+		const result2 = await page.evaluate(() => {
+			const el = document.getElementById('hello');
+			if (el === null){
+				return '#hello not found';
+			}
+			const computed = window.getComputedStyle(el);
+			if (computed.getPropertyValue('color') !== 'rgb(0, 0, 255)'){
+				return 'Bad color: ' + computed.getPropertyValue('color');
+			}
+			return 'ok';
+		});
+		expect(result2).toBe('ok', 'Async color');
+	} finally {
+		await browser.close();
+	}
+});
+
+
+it('SCSS Chunk Filename', async() => {
+	const actualFiles = await testFixture({
+		rootFolder,
+		outputFolder,
+		cssChunkFilename: 'subfolder/custom.chunk.[id].css',
+		mode: 'development',
+		entry: {
+			myapp: './scss-chunks/myapp.ts'
+		},
+		cssModules: true
+	});
+	const expectedFiles = [
+		'index.html',
+		'myapp.css',
+		'myapp.css.map',
+		'myapp.js',
+		'myapp.js.map',
+		'chunk.0.js',
+		'chunk.0.js.map',
+		'subfolder/custom.chunk.0.css',
+		'subfolder/custom.chunk.0.css.map'
+	];
+	expect(actualFiles.sort()).toEqual(expectedFiles.sort());
+
+	const browser = await puppeteer.launch();
+	try {
+		const page = await browser.newPage();
+		await page.goto(`http://localhost:${port}/`);
+		const result1 = await page.evaluate(() => {
+			const el = document.getElementById('hello');
+			if (el === null){
+				return '#hello not found';
+			}
+			const computed = window.getComputedStyle(el);
+			if (computed.getPropertyValue('color') !== 'rgb(0, 255, 0)'){
+				return 'Bad color: ' + computed.getPropertyValue('color');
+			}
+			return 'ok';
+		});
+		expect(result1).toBe('ok', 'Sync color');
+
+		await sleep(300);
+		const result2 = await page.evaluate(() => {
+			const el = document.getElementById('hello');
+			if (el === null){
+				return '#hello not found';
+			}
+			const computed = window.getComputedStyle(el);
+			if (computed.getPropertyValue('color') !== 'rgb(0, 0, 255)'){
+				return 'Bad color: ' + computed.getPropertyValue('color');
+			}
+			return 'ok';
+		});
+		expect(result2).toBe('ok', 'Async color');
+	} finally {
+		await browser.close();
+	}
+});
+
+
+it('SCSS Chunk + SCSS variables', async() => {
+	const actualFiles = await testFixture({
+		rootFolder,
+		outputFolder,
+		scss: `
+			$color1: rgb(0, 128, 0);
+			$color2: rgb(0, 0, 128);
+		`,
+		mode: 'development',
+		entry: {
+			myapp: './scss-chunks-variables/myapp.ts'
+		},
+		cssModules: true
+	});
+	const expectedFiles = [
+		'index.html',
+		'myapp.css',
+		'myapp.css.map',
+		'myapp.js',
+		'myapp.js.map',
+		'chunk.0.js',
+		'chunk.0.js.map',
+		'chunk.0.css',
+		'chunk.0.css.map'
+	];
+	expect(actualFiles.sort()).toEqual(expectedFiles.sort());
+
+	const browser = await puppeteer.launch();
+	try {
+		const page = await browser.newPage();
+		await page.goto(`http://localhost:${port}/`);
+		const result1 = await page.evaluate(() => {
+			const el = document.getElementById('hello');
+			if (el === null){
+				return '#hello not found';
+			}
+			const computed = window.getComputedStyle(el);
+			if (computed.getPropertyValue('color') !== 'rgb(0, 128, 0)'){
+				return 'Bad color: ' + computed.getPropertyValue('color');
+			}
+			return 'ok';
+		});
+		expect(result1).toBe('ok', 'Sync color');
+
+		await sleep(300);
+		const result2 = await page.evaluate(() => {
+			const el = document.getElementById('hello');
+			if (el === null){
+				return '#hello not found';
+			}
+			const computed = window.getComputedStyle(el);
+			if (computed.getPropertyValue('color') !== 'rgb(0, 0, 128)'){
+				return 'Bad color: ' + computed.getPropertyValue('color');
+			}
+			return 'ok';
+		});
+		expect(result2).toBe('ok', 'Async color');
 	} finally {
 		await browser.close();
 	}

--- a/test/fixtures-optimize.spec.js
+++ b/test/fixtures-optimize.spec.js
@@ -352,6 +352,48 @@ it('Chunks', async() => {
 });
 
 
+it('Chunk Filename', async() => {
+	const actualFiles = await testFixture({
+		rootFolder,
+		outputFolder,
+		jsChunkFilename: 'subfolder/custom.chunk.[id].js',
+		mode: 'development',
+		entry: {
+			myapp: './chunks/myapp.ts'
+		}
+	});
+	const expectedFiles = [
+		'index.html',
+		'myapp.js',
+		'myapp.js.map',
+		'subfolder/custom.chunk.0.js',
+		'subfolder/custom.chunk.0.js.map'
+	];
+	expect(actualFiles.sort()).toEqual(expectedFiles.sort());
+
+	const browser = await puppeteer.launch();
+	try {
+		const page = await browser.newPage();
+		await page.goto(`http://localhost:${port}/`);
+		await sleep(300);
+		const found = await page.evaluate(() => {
+			/* global document */
+			const el = document.getElementById('hello');
+			if (el === null){
+				return '#hello not found';
+			}
+			if (el.innerText !== 'Delayed 100123'){
+				return `Bad #hello.innerText: ${el.innerText}`;
+			}
+			return 'ok';
+		});
+		expect(found).toBe('ok', 'DOM tests');
+	} finally {
+		await browser.close();
+	}
+});
+
+
 it('Chunks & Polyfill', async() => {
 	const actualFiles = await testFixture({
 		rootFolder,

--- a/test/fixtures-optimize.spec.js
+++ b/test/fixtures-optimize.spec.js
@@ -1,4 +1,6 @@
 /* eslint-env node, jasmine */
+/* global document */
+/* global window */
 'use strict';
 const {join, relative} = require('path');
 const {readFileSync, mkdirSync} = require('fs');
@@ -178,7 +180,6 @@ it('Minify', async() => {
 		const page = await browser.newPage();
 		await page.goto(`http://localhost:${port}/`);
 		const found = await page.evaluate(() => {
-			/* global document */
 			const el0 = document.getElementById('hello');
 			if (el0 === null){
 				return '#hello not found';
@@ -266,7 +267,6 @@ it('Minify & skipHashes', async() => {
 		const page = await browser.newPage();
 		await page.goto(`http://localhost:${port}/`);
 		const found = await page.evaluate(() => {
-			/* global document */
 			const el0 = document.getElementById('hello');
 			if (el0 === null){
 				return '#hello not found';
@@ -335,7 +335,6 @@ it('Chunks', async() => {
 		await page.goto(`http://localhost:${port}/`);
 		await sleep(300);
 		const found = await page.evaluate(() => {
-			/* global document */
 			const el = document.getElementById('hello');
 			if (el === null){
 				return '#hello not found';
@@ -377,7 +376,6 @@ it('Chunk Filename', async() => {
 		await page.goto(`http://localhost:${port}/`);
 		await sleep(300);
 		const found = await page.evaluate(() => {
-			/* global document */
 			const el = document.getElementById('hello');
 			if (el === null){
 				return '#hello not found';
@@ -423,8 +421,6 @@ it('Chunks & Polyfill', async() => {
 		await page.goto(`http://localhost:${port}/`);
 		await sleep(300);
 		const found = await page.evaluate(() => {
-			/* global document */
-			/* global window */
 			if (typeof window.EXAMPLE_FAKE_POLYFILL !== 'undefined'){
 				return 'Fake polyfill exists';
 			}

--- a/test/fixtures-webworkers.spec.js
+++ b/test/fixtures-webworkers.spec.js
@@ -81,7 +81,7 @@ beforeEach(done => {
 });
 
 
-it('Webworkers', async() => {
+it('Webworker: Basic', async() => {
 	const actualFiles = await testFixture({
 		rootFolder,
 		outputFolder,
@@ -131,7 +131,58 @@ it('Webworkers', async() => {
 });
 
 
-it('Webworkers + Polyfills', async() => {
+it('Webworker: Filename', async() => {
+	const actualFiles = await testFixture({
+		rootFolder,
+		outputFolder,
+		webworkerFilename: 'subfolder/custom.[name].js',
+		mode: 'development',
+		entry: {
+			myapp: './webworkers/myapp.ts'
+		}
+	});
+	const expectedFiles = [
+		'index.html',
+		'myapp.js',
+		'myapp.js.map',
+		'subfolder/custom.relative.webworker.js',
+		'subfolder/custom.relative.webworker.js.map',
+		'subfolder/custom.my-worker-module.webworker.js',
+		'subfolder/custom.my-worker-module.webworker.js.map'
+	];
+	expect(actualFiles.sort()).toEqual(expectedFiles.sort());
+
+	const browser = await puppeteer.launch();
+	try {
+		const page = await browser.newPage();
+		await page.goto(`http://localhost:${port}/`);
+		await sleep(300);
+		const found = await page.evaluate(() => {
+			/* global document */
+			const el1 = document.getElementById('hello1');
+			if (el1 === null){
+				return '#hello1 not found';
+			}
+			if (el1.innerText !== 'RELATIVE WORKER replies HELLO 1'){
+				return `Bad #hello1.innerText: ${el1.innerText}`;
+			}
+			const el2 = document.getElementById('hello2');
+			if (el2 === null){
+				return '#hello2 not found';
+			}
+			if (el2.innerText !== 'MODULE WORKER replies HELLO 2'){
+				return `Bad #hello2.innerText: ${el2.innerText}`;
+			}
+			return 'ok';
+		});
+		expect(found).toBe('ok', 'DOM tests');
+	} finally {
+		await browser.close();
+	}
+});
+
+
+it('Webworker: Polyfills', async() => {
 	const actualFiles = await testFixture({
 		rootFolder,
 		outputFolder,

--- a/test/fixtures-webworkers.spec.js
+++ b/test/fixtures-webworkers.spec.js
@@ -1,4 +1,5 @@
 /* eslint-env node, jasmine */
+/* global document */
 'use strict';
 const {join, relative} = require('path');
 const {mkdirSync} = require('fs');
@@ -107,7 +108,6 @@ it('Webworker: Basic', async() => {
 		await page.goto(`http://localhost:${port}/`);
 		await sleep(300);
 		const found = await page.evaluate(() => {
-			/* global document */
 			const el1 = document.getElementById('hello1');
 			if (el1 === null){
 				return '#hello1 not found';
@@ -158,7 +158,6 @@ it('Webworker: Filename', async() => {
 		await page.goto(`http://localhost:${port}/`);
 		await sleep(300);
 		const found = await page.evaluate(() => {
-			/* global document */
 			const el1 = document.getElementById('hello1');
 			if (el1 === null){
 				return '#hello1 not found';
@@ -215,7 +214,6 @@ it('Webworker: Polyfills', async() => {
 		await page.goto(`http://localhost:${port}/`);
 		await sleep(300);
 		const found = await page.evaluate(() => {
-			/* global document */
 			const el1 = document.getElementById('hello1');
 			if (el1 === null){
 				return '#hello1 not found';

--- a/test/fixtures/chunks/myapp.ts
+++ b/test/fixtures/chunks/myapp.ts
@@ -7,4 +7,4 @@ document.body.appendChild(mydiv);
 setTimeout(async() => {
 	const {mymodule} = await import('mymodule');
 	mydiv.innerText = `Delayed ${mymodule(123)}`;
-})
+});

--- a/test/fixtures/css-chunks/async.css
+++ b/test/fixtures/css-chunks/async.css
@@ -1,0 +1,3 @@
+.myasync {
+	color: rgb(0, 0, 255);
+}

--- a/test/fixtures/css-chunks/myapp.ts
+++ b/test/fixtures/css-chunks/myapp.ts
@@ -1,0 +1,14 @@
+/* eslint-env browser */
+import {mysync} from './sync.css';
+const mydiv = document.createElement('div');
+mydiv.setAttribute('id', 'hello');
+document.body.appendChild(mydiv);
+
+mydiv.className = mysync;
+mydiv.innerText = 'Sync';
+
+setTimeout(async() => {
+	const {myasync} = await import('./async.css');
+	mydiv.className = myasync;
+	mydiv.innerText = 'Async';
+});

--- a/test/fixtures/css-chunks/sync.css
+++ b/test/fixtures/css-chunks/sync.css
@@ -1,0 +1,3 @@
+.mysync {
+	color: rgb(0, 255, 0);
+}

--- a/test/fixtures/scss-chunks-variables/async.scss
+++ b/test/fixtures/scss-chunks-variables/async.scss
@@ -1,0 +1,3 @@
+.myasync {
+	color: $color2;
+}

--- a/test/fixtures/scss-chunks-variables/myapp.ts
+++ b/test/fixtures/scss-chunks-variables/myapp.ts
@@ -1,0 +1,14 @@
+/* eslint-env browser */
+import {mysync} from './sync.scss';
+const mydiv = document.createElement('div');
+mydiv.setAttribute('id', 'hello');
+document.body.appendChild(mydiv);
+
+mydiv.className = mysync;
+mydiv.innerText = 'Sync';
+
+setTimeout(async() => {
+	const {myasync} = await import('./async.scss');
+	mydiv.className = myasync;
+	mydiv.innerText = 'Async';
+});

--- a/test/fixtures/scss-chunks-variables/sync.scss
+++ b/test/fixtures/scss-chunks-variables/sync.scss
@@ -1,0 +1,3 @@
+.mysync {
+	color: $color1;
+}

--- a/test/fixtures/scss-chunks/async.scss
+++ b/test/fixtures/scss-chunks/async.scss
@@ -1,0 +1,5 @@
+$color2: rgb(0, 0, 255);
+
+.myasync {
+	color: $color2;
+}

--- a/test/fixtures/scss-chunks/myapp.ts
+++ b/test/fixtures/scss-chunks/myapp.ts
@@ -1,0 +1,14 @@
+/* eslint-env browser */
+import {mysync} from './sync.scss';
+const mydiv = document.createElement('div');
+mydiv.setAttribute('id', 'hello');
+document.body.appendChild(mydiv);
+
+mydiv.className = mysync;
+mydiv.innerText = 'Sync';
+
+setTimeout(async() => {
+	const {myasync} = await import('./async.scss');
+	mydiv.className = myasync;
+	mydiv.innerText = 'Async';
+});

--- a/test/fixtures/scss-chunks/sync.scss
+++ b/test/fixtures/scss-chunks/sync.scss
@@ -1,0 +1,5 @@
+$color1: rgb(0, 255, 0);
+
+.mysync {
+	color: $color1;
+}

--- a/test/params-assetFilename.spec.js
+++ b/test/params-assetFilename.spec.js
@@ -6,10 +6,10 @@ const getConfig = require('..');
 
 /**
  * @param {String} title
- * @param {String} assetsRelativePath
+ * @param {String} assetFilename
  * @param {Boolean} expectThrows
  */
-function testFixture(title, assetsRelativePath, expectThrows){
+function testFixture(title, assetFilename, expectThrows){
 	it(title, () => {
 		let actualThrows = false;
 		try {
@@ -19,7 +19,7 @@ function testFixture(title, assetsRelativePath, expectThrows){
 				},
 				rootFolder: __dirname,
 				outputFolder: join(__dirname, 'dummy'),
-				assetsRelativePath
+				assetFilename
 			});
 		} catch(e){
 			actualThrows = true;
@@ -28,9 +28,9 @@ function testFixture(title, assetsRelativePath, expectThrows){
 	});
 }
 
+testFixture('Valid: undefined', undefined, false); // eslint-disable-line no-undefined
 testFixture('Valid: ""', '', false);
-testFixture('Valid: "hello/"', 'hello/', false);
-testFixture('Invalid: "hello"', 'hello', true);
+testFixture('Valid: "hello"', 'hello', false);
 testFixture('Invalid: 123', 123, true);
 testFixture('Invalid: {}', {}, true);
 testFixture('Invalid: NaN', NaN, true);

--- a/test/params-cssChunkFilename.spec.js
+++ b/test/params-cssChunkFilename.spec.js
@@ -1,0 +1,41 @@
+/* eslint-env node, jasmine */
+'use strict';
+const {join} = require('path');
+const getConfig = require('..');
+
+
+/**
+ * @param {String} title
+ * @param {String} cssChunkFilename
+ * @param {Boolean} expectThrows
+ */
+function testFixture(title, cssChunkFilename, expectThrows){
+	it(title, () => {
+		let actualThrows = false;
+		try {
+			getConfig({
+				entry: {
+					dummy: './src/dummy.ts'
+				},
+				rootFolder: __dirname,
+				outputFolder: join(__dirname, 'dummy'),
+				cssChunkFilename
+			});
+		} catch(e){
+			actualThrows = true;
+		}
+		expect(actualThrows).toBe(expectThrows);
+	});
+}
+
+testFixture('Valid: undefined', undefined, false); // eslint-disable-line no-undefined
+testFixture('Valid: ""', '', false);
+testFixture('Valid: "hello"', 'hello', false);
+testFixture('Invalid: 123', 123, true);
+testFixture('Invalid: {}', {}, true);
+testFixture('Invalid: NaN', NaN, true);
+testFixture('Invalid: null', null, true);
+testFixture('Invalid: false', false, true);
+testFixture('Invalid: true', true, true);
+testFixture('Invalid: Promise', Promise.resolve(), true);
+testFixture('Invalid: Symbol', Symbol('hello'), true);

--- a/test/params-cssFilename.spec.js
+++ b/test/params-cssFilename.spec.js
@@ -1,0 +1,41 @@
+/* eslint-env node, jasmine */
+'use strict';
+const {join} = require('path');
+const getConfig = require('..');
+
+
+/**
+ * @param {String} title
+ * @param {String} cssFilename
+ * @param {Boolean} expectThrows
+ */
+function testFixture(title, cssFilename, expectThrows){
+	it(title, () => {
+		let actualThrows = false;
+		try {
+			getConfig({
+				entry: {
+					dummy: './src/dummy.ts'
+				},
+				rootFolder: __dirname,
+				outputFolder: join(__dirname, 'dummy'),
+				cssFilename
+			});
+		} catch(e){
+			actualThrows = true;
+		}
+		expect(actualThrows).toBe(expectThrows);
+	});
+}
+
+testFixture('Valid: undefined', undefined, false); // eslint-disable-line no-undefined
+testFixture('Valid: ""', '', false);
+testFixture('Valid: "hello"', 'hello', false);
+testFixture('Invalid: 123', 123, true);
+testFixture('Invalid: {}', {}, true);
+testFixture('Invalid: NaN', NaN, true);
+testFixture('Invalid: null', null, true);
+testFixture('Invalid: false', false, true);
+testFixture('Invalid: true', true, true);
+testFixture('Invalid: Promise', Promise.resolve(), true);
+testFixture('Invalid: Symbol', Symbol('hello'), true);

--- a/test/params-jsChunkFilename.spec.js
+++ b/test/params-jsChunkFilename.spec.js
@@ -1,0 +1,41 @@
+/* eslint-env node, jasmine */
+'use strict';
+const {join} = require('path');
+const getConfig = require('..');
+
+
+/**
+ * @param {String} title
+ * @param {String} jsChunkFilename
+ * @param {Boolean} expectThrows
+ */
+function testFixture(title, jsChunkFilename, expectThrows){
+	it(title, () => {
+		let actualThrows = false;
+		try {
+			getConfig({
+				entry: {
+					dummy: './src/dummy.ts'
+				},
+				rootFolder: __dirname,
+				outputFolder: join(__dirname, 'dummy'),
+				jsChunkFilename
+			});
+		} catch(e){
+			actualThrows = true;
+		}
+		expect(actualThrows).toBe(expectThrows);
+	});
+}
+
+testFixture('Valid: undefined', undefined, false); // eslint-disable-line no-undefined
+testFixture('Valid: ""', '', false);
+testFixture('Valid: "hello"', 'hello', false);
+testFixture('Invalid: 123', 123, true);
+testFixture('Invalid: {}', {}, true);
+testFixture('Invalid: NaN', NaN, true);
+testFixture('Invalid: null', null, true);
+testFixture('Invalid: false', false, true);
+testFixture('Invalid: true', true, true);
+testFixture('Invalid: Promise', Promise.resolve(), true);
+testFixture('Invalid: Symbol', Symbol('hello'), true);

--- a/test/params-jsFilename.spec.js
+++ b/test/params-jsFilename.spec.js
@@ -1,0 +1,41 @@
+/* eslint-env node, jasmine */
+'use strict';
+const {join} = require('path');
+const getConfig = require('..');
+
+
+/**
+ * @param {String} title
+ * @param {String} jsFilename
+ * @param {Boolean} expectThrows
+ */
+function testFixture(title, jsFilename, expectThrows){
+	it(title, () => {
+		let actualThrows = false;
+		try {
+			getConfig({
+				entry: {
+					dummy: './src/dummy.ts'
+				},
+				rootFolder: __dirname,
+				outputFolder: join(__dirname, 'dummy'),
+				jsFilename
+			});
+		} catch(e){
+			actualThrows = true;
+		}
+		expect(actualThrows).toBe(expectThrows);
+	});
+}
+
+testFixture('Valid: undefined', undefined, false); // eslint-disable-line no-undefined
+testFixture('Valid: ""', '', false);
+testFixture('Valid: "hello"', 'hello', false);
+testFixture('Invalid: 123', 123, true);
+testFixture('Invalid: {}', {}, true);
+testFixture('Invalid: NaN', NaN, true);
+testFixture('Invalid: null', null, true);
+testFixture('Invalid: false', false, true);
+testFixture('Invalid: true', true, true);
+testFixture('Invalid: Promise', Promise.resolve(), true);
+testFixture('Invalid: Symbol', Symbol('hello'), true);

--- a/test/params-webworkerFilename.spec.js
+++ b/test/params-webworkerFilename.spec.js
@@ -1,0 +1,41 @@
+/* eslint-env node, jasmine */
+'use strict';
+const {join} = require('path');
+const getConfig = require('..');
+
+
+/**
+ * @param {String} title
+ * @param {String} webworkerFilename
+ * @param {Boolean} expectThrows
+ */
+function testFixture(title, webworkerFilename, expectThrows){
+	it(title, () => {
+		let actualThrows = false;
+		try {
+			getConfig({
+				entry: {
+					dummy: './src/dummy.ts'
+				},
+				rootFolder: __dirname,
+				outputFolder: join(__dirname, 'dummy'),
+				webworkerFilename
+			});
+		} catch(e){
+			actualThrows = true;
+		}
+		expect(actualThrows).toBe(expectThrows);
+	});
+}
+
+testFixture('Valid: undefined', undefined, false); // eslint-disable-line no-undefined
+testFixture('Valid: ""', '', false);
+testFixture('Valid: "hello"', 'hello', false);
+testFixture('Invalid: 123', 123, true);
+testFixture('Invalid: {}', {}, true);
+testFixture('Invalid: NaN', NaN, true);
+testFixture('Invalid: null', null, true);
+testFixture('Invalid: false', false, true);
+testFixture('Invalid: true', true, true);
+testFixture('Invalid: Promise', Promise.resolve(), true);
+testFixture('Invalid: Symbol', Symbol('hello'), true);


### PR DESCRIPTION
Updated `copy-webpack-plugin` and devDependencies.

Removed option `assetsRelativePath` (use `assetFilename` instead).

Added options `assetFilename`, `jsFilename`, `jsChunkFilename`, `webworkerFilename`, `cssFilename`, `cssChunkFilename`.

Changed default filename for CSS chunks.